### PR TITLE
Fix TabLine and TabLineFill

### DIFF
--- a/colors/spacecamp.vim
+++ b/colors/spacecamp.vim
@@ -87,6 +87,8 @@ call <sid>hi('StatusLine', s:spaceBlack, s:spaceSteel, 'none')
 call <sid>hi('StatusLineNC', s:spaceGray3, s:spaceBlack2, 'none')
 call <sid>hi('VertSplit', s:spaceGray3, s:spaceGray3, 'none')
 call <sid>hi('Visual', s:none, s:spaceGray2, 'none')
+call <sid>hi('TabLine', s:spaceSteel, s:spaceGray2, 'none')
+call <sid>hi('TabLineFill', s:spaceBlack, s:spaceBlack, 'none')
 
 " General
 call <sid>hi('Boolean', s:spaceGoo, s:none, 'none')

--- a/colors/spacecamp_lite.vim
+++ b/colors/spacecamp_lite.vim
@@ -87,6 +87,8 @@ call <sid>hi('StatusLine', s:spaceBlack, s:spaceSteel, 'none')
 call <sid>hi('StatusLineNC', s:spaceGray3, s:spaceBlack2, 'none')
 call <sid>hi('VertSplit', s:spaceGray3, s:spaceGray3, 'none')
 call <sid>hi('Visual', s:none, s:spaceGray2, 'none')
+call <sid>hi('TabLine', s:spaceSteel, s:spaceGray2, 'none')
+call <sid>hi('TabLineFill', s:spaceBlack, s:spaceBlack, 'none')
 
 " General
 call <sid>hi('Boolean', s:spaceGoo, s:none, 'none')


### PR DESCRIPTION
The TabLine (see `:h TabLine`) was not styled, so it showed up as a glaring white. This does not fit the theme at all.

I saw that there are styles for a plugin `BufTabLine`, so I copied the styles for `TabLine`.