### PR TITLE
Update spacecamp_windows_terminal.json Typo

### DIFF
--- a/.terminal_themes/spacecamp_windows_terminal.json
+++ b/.terminal_themes/spacecamp_windows_terminal.json
@@ -1,7 +1,7 @@
 /*
 
 1. Go to Windows Terminal Settings and Open JSON file
-2. Copy the following code inside the schema tab in the JSON file
+2. Copy the following code inside the schemes tab in the JSON file
 3. Go to Default > Appearance and change Color Scheme to Spacecamp
 
 */


### PR DESCRIPTION

Updated the Instructions for windows_terminal from "schema" to "schemes"

![image](https://github.com/jaredgorski/SpaceCamp/assets/41871666/2c23a4e0-ddb4-4839-8feb-7bede7fc9993)
